### PR TITLE
A way to break transactions powered by overwriting the default thread pool

### DIFF
--- a/build/resources/main/log4j2.yml
+++ b/build/resources/main/log4j2.yml
@@ -7,9 +7,7 @@ Configuration:
       PatternLayout:
         Pattern: "%style{\
             %date{yyyy-MM-dd HH:mm:ss.SSS}\
-            }{white} \
-            \
-            [%mdc{txid}] \
+            } \
             \
             %highlight{%-5level}{FATAL=Blinking bright red, ERROR=Red, WARN=Yellow, INFO=Cyan, DEBUG=White, TRACE=Black} \
             \
@@ -20,7 +18,7 @@ Configuration:
             %style{\
             %40.40logger\
             }{cyan} - \
-            \
+            [MDC TX %mdc{txid}] \
             %msg%n%throwable\
             "
   Loggers:

--- a/build/resources/main/log4j2.yml
+++ b/build/resources/main/log4j2.yml
@@ -18,7 +18,7 @@ Configuration:
             %style{\
             %40.40logger\
             }{cyan} - \
-            [MDC TX %mdc{txid}] \
+            [MDC TX = %mdc{txid}] \
             %msg%n%throwable\
             "
   Loggers:

--- a/build/tmp/compileJava/source-classes-mapping.txt
+++ b/build/tmp/compileJava/source-classes-mapping.txt
@@ -1,8 +1,8 @@
 async/MdcWrapperHelper.java
  async.MdcWrapperHelper
-async/MdcAwareForkJoinPool.java
- async.MdcAwareForkJoinPool
 async/MdcAwareThreadPool.java
  async.MdcAwareThreadPool
+async/MdcAwareForkJoinPool.java
+ async.MdcAwareForkJoinPool
 async/CompletableFutureTest.java
  async.CompletableFutureTest

--- a/src/main/java/async/MdcAwareForkJoinPool.java
+++ b/src/main/java/async/MdcAwareForkJoinPool.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import static async.MdcWrapperHelper.wrapWithMdcContext;
 
@@ -28,7 +29,7 @@ public class MdcAwareForkJoinPool extends ForkJoinPool {
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) {
-        return super.invokeAll(wrapWithMdcContext(tasks));
+        return super.invokeAll(wrapWithMdcContext(tasks.stream().map(it -> (Callable<T>)it).collect(Collectors.toList())));
     }
 
     @Override

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -7,9 +7,7 @@ Configuration:
       PatternLayout:
         Pattern: "%style{\
             %date{yyyy-MM-dd HH:mm:ss.SSS}\
-            }{white} \
-            \
-            [%mdc{txid}] \
+            } \
             \
             %highlight{%-5level}{FATAL=Blinking bright red, ERROR=Red, WARN=Yellow, INFO=Cyan, DEBUG=White, TRACE=Black} \
             \
@@ -20,7 +18,7 @@ Configuration:
             %style{\
             %40.40logger\
             }{cyan} - \
-            \
+            [MDC TX %mdc{txid}] \
             %msg%n%throwable\
             "
   Loggers:

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -18,7 +18,7 @@ Configuration:
             %style{\
             %40.40logger\
             }{cyan} - \
-            [MDC TX %mdc{txid}] \
+            [MDC TX = %mdc{txid}] \
             %msg%n%throwable\
             "
   Loggers:


### PR DESCRIPTION
The basic idea is to return an incomplete future, then use CompletableFuture.complete() in a separate, non-MDC-aware executor (here using a fixed thread pool as an example). Unsurprisingly, this breaks the transaction logging.

Using the CompletableFuture as a simple container for a not-yet-returned value seems like a pretty reasonable thing to do